### PR TITLE
Fix little typo in Dockerfile

### DIFF
--- a/acme-dist/src/main/docker/keycloak/Dockerfile
+++ b/acme-dist/src/main/docker/keycloak/Dockerfile
@@ -3,5 +3,5 @@ FROM quay.io/keycloak/keycloak:$KEYCLOAK_VERSION
 
 COPY --chown=jboss:jboss maven/cli/ /opt/jboss/startup-scripts
 COPY --chown=jboss:jboss maven/acme-extensions/ /opt/jboss/keycloak/standalone/deployments
-COPY --chown=jboss:jboss maven/acme-theme /opt/jboss/keycloak/theme/acme
+COPY --chown=jboss:jboss maven/acme-theme /opt/jboss/keycloak/themes/acme
 


### PR DESCRIPTION
Hi Thomas,

war gerade bisschen mit dem Beispiel-Code am rumspielen. Dabei ist mir aufgefallen, dass das Custom Theme zwar korrekt geladen wird, wenn man über docker-compose startet, allerdings nicht wenn man das gebaute Image direkt ausführt.

Habe den Pfad im Dockerfile angepasst.

Gruß,
Cedric